### PR TITLE
chore: fix a non working example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,12 +20,10 @@ const states: Array<State> = [
   {
     id: "OFF", // id of the state
     initial: true, // when started the machine will execute it as first
-    transitionGuard: () => true, // guard that validate if the transition can be applied
     transitionTo: () => "ON", // return the id of the state you want to transition to
   },
   {
     id: "ON",
-    transitionGuard: () => true,
     transitionTo: () => "OFF",
   },
 ];

--- a/README.md
+++ b/README.md
@@ -20,10 +20,12 @@ const states: Array<State> = [
   {
     id: "OFF", // id of the state
     initial: true, // when started the machine will execute it as first
+    transitionGuard: () => true, // guard that validate if the transition can be applied
     transitionTo: () => "ON", // return the id of the state you want to transition to
   },
   {
     id: "ON",
+    transitionGuard: () => true,
     transitionTo: () => "OFF",
   },
 ];

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -29,15 +29,21 @@ export function validateStates<TContext, TEvent>(
 		throw new InvalidStateIdError("Ids must be unique");
 	}
 
-	if (!states.every((s) => s.final || s.autoTransition || s.transitionGuard)) {
-		throw new InvalidTransitionCondition(
-			"State must have valid transition condition (autoTransition or transitionGuard) if not final",
-		);
-	}
-
 	if (states.some((s) => s.autoTransition && s.transitionGuard)) {
 		throw new InvalidTransitionCondition(
 			"State with autoTransition cannot have property transitionGuard",
+		);
+	}
+
+	if (
+		states.some(
+			(s) =>
+				(!s.final && !s.transitionTo) ||
+				(s.final && (s.autoTransition || s.transitionTo || s.transitionGuard)),
+		)
+	) {
+		throw new InvalidTransitionCondition(
+			"State must have valid transition condition (autoTransition or transitionGuard) if not final",
 		);
 	}
 

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -43,7 +43,7 @@ export function validateStates<TContext, TEvent>(
 		)
 	) {
 		throw new InvalidTransitionCondition(
-			"State must have valid transition condition (autoTransition or transitionGuard) if not final",
+			"State must have autoTransition or transitionTo if not final",
 		);
 	}
 

--- a/test/fixtures/fixtures.js
+++ b/test/fixtures/fixtures.js
@@ -8,7 +8,7 @@ export const basicStates = [
 	},
 ];
 
-export const missingAutoTransition = [
+export const withoutAutoTransition = [
 	{ id: "ON", final: true },
 	{
 		id: "OFF",

--- a/test/fsm.spec.js
+++ b/test/fsm.spec.js
@@ -5,7 +5,6 @@ import {
 	StateMachine,
 	InvalidConstructor,
 } from "../dist/index.js";
-import { InvalidTransitionCondition } from "../dist/validate.js";
 import * as fixtures from "./fixtures/fixtures.js";
 
 test("state machine constructor", async () => {
@@ -24,11 +23,14 @@ test("state machine wrong destination", async () => {
 	await assert.rejects(machine.start(), InvalidTransition);
 });
 
-test("missing auto transition", () => {
-	assert.throws(
-		() => StateMachine.from(fixtures.missingAutoTransition),
-		InvalidTransitionCondition,
-	);
+test("without auto transition", () => {
+	assert.doesNotThrow(async () => {
+		const machine = StateMachine.from(fixtures.withoutAutoTransition);
+		await machine.start();
+		assert.deepStrictEqual(machine.currentStateId, "OFF");
+		await machine.send();
+		assert.deepStrictEqual(machine.currentStateId, "ON");
+	});
 });
 
 test("autoTransition", async () => {

--- a/test/validate.spec.js
+++ b/test/validate.spec.js
@@ -43,33 +43,6 @@ test("validates states correctly", () => {
 			]),
 		InvalidTransitionCondition,
 	);
-	assert.doesNotThrow(() =>
-		validateStates([
-			{ initial: true, id: "A", autoTransition: true },
-			{ initial: false, id: "B", autoTransition: true },
-		]),
-	);
-	assert.doesNotThrow(() =>
-		validateStates([
-			{ initial: true, id: "A", transitionGuard: true },
-			{ initial: false, id: "B", autoTransition: true },
-		]),
-	);
-
-	assert.throws(
-		() =>
-			validateStates([
-				{
-					initial: true,
-					id: "A",
-					transitionTo: () => "B",
-					autoTransition: true,
-					transitionGuard: () => {},
-				},
-				{ final: true, id: "B" },
-			]),
-		InvalidTransitionCondition,
-	);
 
 	assert.throws(
 		() =>
@@ -82,6 +55,302 @@ test("validates states correctly", () => {
 					onFinal: () => {},
 				},
 				{ final: true, id: "B" },
+			]),
+		InvalidTransitionCondition,
+	);
+
+	/**
+	 * Test all combinations of:
+	 * - final
+	 * - autoTransition
+	 * - transitionGuard
+	 * - transitionTo
+	 */
+
+	assert.throws(
+		() =>
+			validateStates([
+				{
+					id: "A",
+					initial: true,
+					transitionTo: () => "B",
+				},
+				{
+					// state to validate
+					id: "B",
+					final: true,
+					autoTransition: true,
+					transitionGuard: () => true,
+					transitionTo: () => "A",
+				},
+			]),
+		InvalidTransitionCondition,
+	);
+
+	assert.throws(
+		() =>
+			validateStates([
+				{
+					id: "A",
+					initial: true,
+					transitionTo: () => "B",
+				},
+				{
+					// state to validate
+					id: "B",
+					final: true,
+					autoTransition: true,
+					transitionGuard: () => true,
+				},
+			]),
+		InvalidTransitionCondition,
+	);
+
+	assert.throws(
+		() =>
+			validateStates([
+				{
+					id: "A",
+					initial: true,
+					transitionTo: () => "B",
+				},
+				{
+					// state to validate
+					id: "B",
+					final: true,
+					autoTransition: true,
+					transitionTo: () => "B",
+				},
+			]),
+		InvalidTransitionCondition,
+	);
+
+	assert.throws(
+		() =>
+			validateStates([
+				{
+					id: "A",
+					initial: true,
+					transitionTo: () => "B",
+				},
+				{
+					// state to validate
+					id: "B",
+					final: true,
+					autoTransition: true,
+				},
+			]),
+		InvalidTransitionCondition,
+	);
+
+	assert.throws(
+		() =>
+			validateStates([
+				{
+					id: "A",
+					initial: true,
+					transitionTo: () => "B",
+				},
+				{
+					// state to validate
+					id: "B",
+					final: true,
+					transitionGuard: () => true,
+					transitionTo: () => "A",
+				},
+			]),
+		InvalidTransitionCondition,
+	);
+
+	assert.throws(
+		() =>
+			validateStates([
+				{
+					id: "A",
+					initial: true,
+					transitionTo: () => "B",
+				},
+				{
+					// state to validate
+					id: "B",
+					final: true,
+					transitionGuard: () => true,
+				},
+			]),
+		InvalidTransitionCondition,
+	);
+
+	assert.throws(
+		() =>
+			validateStates([
+				{
+					id: "A",
+					initial: true,
+					transitionTo: () => "B",
+				},
+				{
+					// state to validate
+					id: "B",
+					final: true,
+					transitionTo: () => "A",
+				},
+			]),
+		InvalidTransitionCondition,
+	);
+
+	assert.doesNotThrow(() =>
+		validateStates([
+			{
+				id: "A",
+				initial: true,
+				transitionTo: () => "B",
+			},
+			{
+				// state to validate
+				id: "B",
+				final: true,
+			},
+		]),
+	);
+
+	assert.throws(
+		() =>
+			validateStates([
+				{
+					id: "A",
+					initial: true,
+					autoTransition: true,
+					transitionTo: () => "B",
+				},
+				{
+					// state to validate
+					id: "B",
+					autoTransition: true,
+					transitionGuard: () => true,
+					transitionTo: () => "A",
+				},
+			]),
+		InvalidTransitionCondition,
+	);
+
+	assert.throws(
+		() =>
+			validateStates([
+				{
+					id: "A",
+					initial: true,
+					autoTransition: true,
+					transitionTo: () => "B",
+				},
+				{
+					// state to validate
+					id: "B",
+					autoTransition: true,
+					transitionGuard: () => true,
+				},
+			]),
+		InvalidTransitionCondition,
+	);
+
+	assert.doesNotThrow(() =>
+		validateStates([
+			{
+				id: "A",
+				initial: true,
+				autoTransition: true,
+				transitionTo: () => "B",
+			},
+			{
+				// state to validate
+				id: "B",
+				autoTransition: true,
+				transitionTo: () => "A",
+			},
+		]),
+	);
+
+	assert.throws(
+		() =>
+			validateStates([
+				{
+					id: "A",
+					initial: true,
+					autoTransition: true,
+					transitionTo: () => "B",
+				},
+				{
+					// state to validate
+					id: "B",
+					autoTransition: true,
+				},
+			]),
+		InvalidTransitionCondition,
+	);
+
+	assert.doesNotThrow(() =>
+		validateStates([
+			{
+				id: "A",
+				initial: true,
+				autoTransition: true,
+				transitionTo: () => "B",
+			},
+			{
+				// state to validate
+				id: "B",
+				transitionGuard: () => true,
+				transitionTo: () => "A",
+			},
+		]),
+	);
+
+	assert.throws(
+		() =>
+			validateStates([
+				{
+					id: "A",
+					initial: true,
+					autoTransition: true,
+					transitionTo: () => "B",
+				},
+				{
+					// state to validate
+					id: "B",
+					transitionGuard: () => true,
+				},
+			]),
+		InvalidTransitionCondition,
+	);
+
+	assert.doesNotThrow(() =>
+		validateStates([
+			{
+				id: "A",
+				initial: true,
+				autoTransition: true,
+				transitionTo: () => "B",
+			},
+			{
+				// state to validate
+				id: "B",
+				transitionTo: () => "B",
+			},
+		]),
+	);
+
+	assert.throws(
+		() =>
+			validateStates([
+				{
+					id: "A",
+					initial: true,
+					autoTransition: true,
+					transitionTo: () => "B",
+				},
+				{
+					// state to validate
+					id: "B",
+				},
 			]),
 		InvalidTransitionCondition,
 	);


### PR DESCRIPTION
The current version of the example fails with:

```
throw new InvalidTransitionCondition("State must have valid transition condition (autoTransition or transitionGuard) if not final");
```